### PR TITLE
Update pop-live-disk.md

### DIFF
--- a/docs/pop-live-disk.md
+++ b/docs/pop-live-disk.md
@@ -25,6 +25,10 @@ Popsicle is an open source app for Linux that allows you to "burn images to USB 
 sudo apt install popsicle-gtk
 ```
 
+Of course, if you were running Pop!_OS already, you wouldn't need these instructions!  Which makes the above advice really pointlesss.  It'd be great if someone could edit this with instructions on how to create a bootable Pop!_OS USB drive on OTHER distributions (ie. the kind everyone will be migrating from, to get to Pop).
+
+On any Debian-based distrubtion, it's likely as simple as adding a single additional repository ... but personally I don't know what repo that would be.
+
 Once you have installed Popsicle and downloaded the Pop!_OS.iso image, open the Popsicle application.
 
 ![Popsicle](/images/pop-live-disk/popsicle.png)


### PR DESCRIPTION
Added (essentially) a TODO for non-Pop instructions (which seems like a *glaring* oversight: who thought it would  be a good idea to write the instructions as if you already had the OS you are trying to get?)

Really though my true hope is that this PR will be rejected, and replaced with one that actually explains how to instal Pop from a non-Pop source.